### PR TITLE
Fix: Resolve image shift issue after cropping

### DIFF
--- a/style.css
+++ b/style.css
@@ -31,15 +31,12 @@ body {
 }
 
 .image-display-area {
-    flex-grow: 1;
-    padding: 20px;
     display: flex;
-    justify-content: center;
-    align-items: center;
+    margin: auto; /* Center it in its parent */
     background-color: #e9e9e9;
     overflow: auto; /* Add scrollbars if canvas is too big */
-    height: calc(100vh - 40px); /* Adjust based on body padding */
-    max-height: 800px; /* Max height for the display area */
+    height: auto; /* Adjust height automatically */
+    max-height: 100%; /* Max height respects parent constraints */
     position: relative; /* Needed for absolute positioning of cropOverlay */
 }
 
@@ -48,6 +45,7 @@ body {
     max-height: 100%;
     object-fit: contain;
     border: 1px solid #ccc;
+    display: block; /* Avoid extra space if it defaults to inline */
 }
 
 .upload-section,


### PR DESCRIPTION
The problem was caused by the `.image-display-area` CSS being larger than the canvas due to padding and using flexbox properties (`justify-content`, `align-items`) to center the canvas internally. After a crop operation, the new (often smaller) canvas would be re-centered within this larger area, causing its content to appear shifted relative to its position before the crop.

This commit addresses the issue by:
1. Modifying `.image-display-area` CSS:
    - Removed `padding`.
    - Removed `justify-content: center` and `align-items: center`.
    - Removed `flex-grow: 1`.
    - Set `height: auto` to allow it to shrink with the canvas.
    - Added `margin: auto` to center the `image-display-area` itself within its parent container.
    - Ensured `max-height` is still reasonably constrained (now `100%` of parent, which is typically limited by `controls-panel` height).
2. Modifying `#imageCanvas` CSS:
    - Ensured `display: block` to prevent potential inline spacing issues.
    - Retained `max-width: 100%` and `max-height: 100%` for proper scaling within the modified `image-display-area`.

With these changes, `.image-display-area` now wraps the `#imageCanvas` more tightly. `canvas.offsetLeft` and `canvas.offsetTop` (relative to `.image-display-area`) will be zero or close to zero. This simplifies the coordinate system for the cropping UI and ensures that after a crop, the new canvas is drawn at the top-left of the `image-display-area`, which then resizes and is centered. This prevents the unexpected shift of the image content.

The JavaScript logic for cropping, particularly in `ImageEditor.js`, was reviewed and deemed compatible with these CSS changes without requiring modification, as it correctly uses `canvas.offsetLeft/Top` for its calculations.